### PR TITLE
Disable destination folder in Transmission

### DIFF
--- a/transmission-web/patches/disable-destination-folder.patch
+++ b/transmission-web/patches/disable-destination-folder.patch
@@ -1,0 +1,13 @@
+diff --git a/web/index.html b/web/index.html
+index 06a5c81..f354cdd 100755
+--- a/web/index.html
++++ b/web/index.html
+@@ -292,7 +292,7 @@
+ 						<label for="torrent_upload_url">Or enter a URL:</label>
+ 							<input type="url" id="torrent_upload_url"/>
+ 						<label id='add-dialog-folder-label' for="add-dialog-folder-input">Destination folder:</label>
+-							<input type="text" id="add-dialog-folder-input"/>
++							<input type="text" id="add-dialog-folder-input" disabled />
+ 							<input type="checkbox" id="torrent_auto_start" />
+ 						<label for="torrent_auto_start" id="auto_start_label">Start when added</label>
+ 					</div>


### PR DESCRIPTION
Users may be confused where the destination folder is located in, change it and experience some side effects. It's better to prevent them from changing it at all.