### PR TITLE
vsftpd: fix port number

### DIFF
--- a/vsftpd/README.md
+++ b/vsftpd/README.md
@@ -41,6 +41,6 @@ Read the [Getting Started](https://github.com/tolstoyevsky/mmb#getting-started) 
 
 | Parameter | Description | Default |
 | --- | --- | --- |
-| PORT     | Port the FTP server listens on                        | 3478   |
+| PORT     | Port the FTP server listens on                        | 2121   |
 | USERNAME | User which will be created when the FTP server starts | cusdeb |
 | PASSWORD | User password                                         | cusdeb |

--- a/vsftpd/docker-compose-armhf.yml
+++ b/vsftpd/docker-compose-armhf.yml
@@ -4,7 +4,7 @@ services:
     image: cusdeb/vsftpd:3.0.3-armhf
     command: /usr/bin/run.sh
     environment:
-    - PORT=8004
+    - PORT=2121
     - USERNAME=cusdeb
     - PASSWORD=cusdeb
     network_mode: "host"

--- a/vsftpd/docker-compose.yml
+++ b/vsftpd/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: cusdeb/vsftpd:3.0.3-amd64
     command: /usr/bin/run.sh
     environment:
-    - PORT=8004
+    - PORT=2121
     - USERNAME=cusdeb
     - PASSWORD=cusdeb
     network_mode: "host"


### PR DESCRIPTION
README says the default port number is `3478`, but `docker-compose.yml` says it's `8004`. It has to be fixed. However, I suggest we will change the port used by default to `2121` since in MMB ports starting from `8001` are used for the services the ports of which belong to neither [well-known ports](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports) nor the [registered ports](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Registered_ports). FTP servers have to listen on well-known port `21`. But we don't want our vsftpd to intersect with those which are already installed on the target machine. So, the port number has to be a hint of `21`. Let it be `2121`. 