### PR TITLE
redis: substitute RDB for AOF

### DIFF
--- a/redis/docker-compose.yml
+++ b/redis/docker-compose.yml
@@ -6,6 +6,10 @@ services:
     environment:
     - REDIS_CONF_bind=127.0.0.1
     - REDIS_CONF_port=16379
+    # Enable AOF
+    - REDIS_CONF_appendonly=yes
+    # Disable RDB
+    - REDIS_CONF_save=
     - REDIS_CONF_loglevel=notice
     volumes:
     - /srv/redis-dump:/dump


### PR DESCRIPTION
The AOF persistence is more durable than RDB since it logs every write operation received by the server. Currently Redis is used for Hubot adapter for Rocket.Chat. I think the AOF persistence is the best option for the case.