### PR TITLE
qemu: do not mention armhf port in README

### DIFF
--- a/qemu/README.md
+++ b/qemu/README.md
@@ -26,10 +26,7 @@ The Dockerfile and assets related to it are intended primarily, but **not** excl
   </tr>
   <tr>
     <td valign="top">Base images</td>
-    <td>
-        <code>cusdeb/alpine3.7:armhf</code> (for <code>armhf</code> port)<br>
-        <code>cusdeb/alpine3.7:amd64</code> (for <code>amd64</code> port)
-    </td>
+    <td><code>cusdeb/alpine3.7:amd64</code></td>
   </tr>
 </table>
 


### PR DESCRIPTION
The point is that the image doesn't support it.