### PR TITLE
Upgrade Hubot adapter to version 2.0 (development) from 1.0.11

### DIFF
--- a/hubot-rocketchat/Dockerfile
+++ b/hubot-rocketchat/Dockerfile
@@ -9,7 +9,7 @@ ENV BOT_DESC "Hubot with rocketbot adapter"
 
 ENV HUBOT_VERSION 2.19.0
 
-ENV RC_HUBOT_VERSION 1.0.11
+ENV RC_HUBOT_BRANCH 930d085472bb9afa122721fa1b0bec59a783b86b
 
 RUN apk --update add \
     bash \
@@ -28,7 +28,7 @@ RUN apk --update add \
  && sed -i /heroku/d ./external-scripts.json \
  && sed -i /redis-brain/d ./external-scripts.json \
  && sudo -u hubot npm install hubot@$HUBOT_VERSION \
- && sudo -u hubot npm install hubot-rocketchat@$RC_HUBOT_VERSION \
+ && sudo -u hubot npm install git+https://git@github.com/RocketChat/hubot-rocketchat.git#$RC_HUBOT_BRANCH \
  # Cleanup
  && apk del \
     curl \

--- a/hubot-rocketchat/README.md
+++ b/hubot-rocketchat/README.md
@@ -8,11 +8,11 @@ Rocket.Chat Hubot adapter is the way to integrate [Hubot](https://hubot.github.c
   </tr>
   <tr>
     <td>Version</td>
-    <td><a href="https://github.com/RocketChat/hubot-rocketchat/releases/tag/v1.0.11">1.0.11</a></td>
+    <td>2.0 (<a href="https://github.com/RocketChat/hubot-rocketchat/commit/930d085472bb9afa122721fa1b0bec59a783b86b">930d085472bb9afa122721fa1b0bec59a783b86b</a>)</td>
   </tr>
   <tr>
     <td>Release date</td>
-    <td>07 Aug 2017</td>
+    <td>04 Jun 2018</td>
   </tr>
   <tr>
     <td valign="top">Base images</td>

--- a/hubot-rocketchat/docker-compose-armhf.yml
+++ b/hubot-rocketchat/docker-compose-armhf.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   hubot-rocketchat:
-    image: cusdeb/hubot-rocketchat:1.0.11-armhf
+    image: cusdeb/hubot-rocketchat:2.0-armhf
     network_mode: "host"
     environment:
     - ROCKETCHAT_URL=${ROCKETCHAT_URL}

--- a/hubot-rocketchat/docker-compose.yml
+++ b/hubot-rocketchat/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   hubot-rocketchat:
-    image: cusdeb/hubot-rocketchat:1.0.11-amd64
+    image: cusdeb/hubot-rocketchat:2.0-amd64
     network_mode: "host"
     environment:
     - ROCKETCHAT_URL=${ROCKETCHAT_URL}


### PR DESCRIPTION
The main reason why I suggest update our Hubot adapter is that `robot.adapter.api` is not available in 1.0.11 (the version which we are using right now). `robot.adapter.api` allows the bot to check whether this or that user exists or which roles he/she belongs to.
The new version of the adapter is compatible with the third-party scripts written in CoffeeScript (we use a few of them). However, in the future the developers of the adapter promise to break the compatibility.