### PR TITLE
hubot-rocketchat: remove hubot-thecat script

### DIFF
--- a/hubot-rocketchat/README.md
+++ b/hubot-rocketchat/README.md
@@ -40,7 +40,6 @@ The following set of scripts makes the bot capable of doing all sort of things:
 * [hubot-pugme](https://github.com/tolstoyevsky/hubot-pugme) – shows random pictures with pugs.
 * [hubot-reaction](https://github.com/hubot-scripts/hubot-reaction) – interacts with [replygif.net](http://replygif.net).
 * [hubot-redis-brain](https://github.com/hubotio/hubot-redis-brain) – allows using Redis as an alternative storage backend for the Hubot in-memory key-value storage exposed as `robot.brain`.
-* [hubot-thecat](https://github.com/tenten0213/hubot-thecat) – interacts with [The Cat API](http://thecatapi.com).
 * [hubot-thesimpsons](https://github.com/hubot-scripts/hubot-thesimpsons) – generates the quotes and images related to The Simpsons.
 * [hubot-vote-or-die](https://github.com/tolstoyevsky/hubot-vote-or-die) – allows building polls.
 

--- a/hubot-rocketchat/docker-entrypoint.sh
+++ b/hubot-rocketchat/docker-entrypoint.sh
@@ -10,7 +10,7 @@ ROCKETCHAT_USER=${ROCKETCHAT_USER:="meeseeks"}
 
 ROCKETCHAT_PASSWORD=${ROCKETCHAT_PASSWORD:="pass"}
 
-EXTERNAL_SCRIPTS=${EXTERNAL_SCRIPTS:="git:hubot-scripts/hubot-auth,git:tolstoyevsky/hubot-happy-birthder,hubot-help,git:tolstoyevsky/hubot-pugme,hubot-reaction,hubot-redis-brain,git:tenten0213/hubot-thecat,hubot-thesimpsons,git:tolstoyevsky/hubot-vote-or-die"}
+EXTERNAL_SCRIPTS=${EXTERNAL_SCRIPTS:="git:hubot-scripts/hubot-auth,git:tolstoyevsky/hubot-happy-birthder,hubot-help,git:tolstoyevsky/hubot-pugme,hubot-reaction,hubot-redis-brain,hubot-thesimpsons,git:tolstoyevsky/hubot-vote-or-die"}
 
 HUBOT_NAME=${HUBOT_NAME:="bot"}
 


### PR DESCRIPTION
* It doesn't have limits of cats (it's possible to hang all the clients with `cat bomb`).
* It stopped working with the latest versions of Hubot and Rocket.Chat.