### PR TITLE
hubot-rocketchat: do not use hubot-auth

### DIFF
--- a/hubot-rocketchat/README.md
+++ b/hubot-rocketchat/README.md
@@ -34,7 +34,6 @@ Rocket.Chat Hubot adapter is the way to integrate [Hubot](https://hubot.github.c
 
 The following set of scripts makes the bot capable of doing all sort of things:
 
-* [hubot-auth](https://github.com/hubot-scripts/hubot-auth) – allows assigning roles to users and restricting command access in other scripts.
 * [hubot-happy-birthder](https://github.com/tolstoyevsky/hubot-happy-birthder) – writes birthday messages to users.
 * [hubot-help](https://github.com/hubotio/hubot-help) – shows available commands.
 * [hubot-pugme](https://github.com/tolstoyevsky/hubot-pugme) – shows random pictures with pugs.
@@ -102,11 +101,6 @@ By default, the packages from the list <a href="#features">above</a> will be ins
   </tr>
   <tr>
     <td align="center" colspan="3"><b>hubot-auth</b></td>
-  </tr>
-  <tr>
-    <td>HUBOT_AUTH_ADMIN</td>
-    <td>Comma-separated list containing the ids of the users who must have the admin rore. To get to know your user id, use the bot command <code>what is my id</code>.</td>
-    <td></td>
   </tr>
   <tr>
     <td align="center" colspan="3"><b>hubot-happy-birthder</b></td>

--- a/hubot-rocketchat/docker-compose-armhf.yml
+++ b/hubot-rocketchat/docker-compose-armhf.yml
@@ -12,8 +12,6 @@ services:
     - HUBOT_NAME=${HUBOT_NAME}
     - LISTEN_ON_ALL_PUBLIC=${LISTEN_ON_ALL_PUBLIC}
     - TZ=${TZ}
-    # hubot-auth
-    - HUBOT_AUTH_ADMIN=${HUBOT_AUTH_ADMIN}
     # hubot-happy-birthder
     - TENOR_API_KEY=${TENOR_API_KEY}
     - TENOR_IMG_LIMIT=${TENOR_IMG_LIMIT}

--- a/hubot-rocketchat/docker-compose.yml
+++ b/hubot-rocketchat/docker-compose.yml
@@ -12,8 +12,6 @@ services:
     - HUBOT_NAME=${HUBOT_NAME}
     - LISTEN_ON_ALL_PUBLIC=${LISTEN_ON_ALL_PUBLIC}
     - TZ=${TZ}
-    # hubot-auth
-    - HUBOT_AUTH_ADMIN=${HUBOT_AUTH_ADMIN}
     # hubot-happy-birthder
     - TENOR_API_KEY=${TENOR_API_KEY}
     - TENOR_IMG_LIMIT=${TENOR_IMG_LIMIT}

--- a/hubot-rocketchat/docker-entrypoint.sh
+++ b/hubot-rocketchat/docker-entrypoint.sh
@@ -10,7 +10,7 @@ ROCKETCHAT_USER=${ROCKETCHAT_USER:="meeseeks"}
 
 ROCKETCHAT_PASSWORD=${ROCKETCHAT_PASSWORD:="pass"}
 
-EXTERNAL_SCRIPTS=${EXTERNAL_SCRIPTS:="git:hubot-scripts/hubot-auth,git:tolstoyevsky/hubot-happy-birthder,hubot-help,git:tolstoyevsky/hubot-pugme,hubot-reaction,hubot-redis-brain,hubot-thesimpsons,git:tolstoyevsky/hubot-vote-or-die"}
+EXTERNAL_SCRIPTS=${EXTERNAL_SCRIPTS:="git:tolstoyevsky/hubot-happy-birthder,hubot-help,git:tolstoyevsky/hubot-pugme,hubot-reaction,hubot-redis-brain,hubot-thesimpsons,git:tolstoyevsky/hubot-vote-or-die"}
 
 HUBOT_NAME=${HUBOT_NAME:="bot"}
 


### PR DESCRIPTION
The newest version of `hubot-happy-birthder` uses Hubot functions to check whether the specified user is admin.