### PR TITLE
rocketchat: bump to 1.1.3

### DIFF
--- a/rocketchat/Dockerfile
+++ b/rocketchat/Dockerfile
@@ -6,7 +6,7 @@ ENV BUNDLE_DIR /home/rocketchat/bundle
 # Rocket.Chat Buildmaster <buildmaster@rocket.chat>
 ENV PUBLIC_KEY 0E163286C20D07B9787EBE9FD7F9D0414FD08104
 
-ENV RC_VERSION 0.70.4
+ENV RC_VERSION 1.1.3
 
 RUN apt-get update \
  && apt-get install -y \

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -32,6 +32,25 @@ Rocket.Chat is a self-hosted alternative to Slack.
 
 Read the [Getting Started](https://github.com/tolstoyevsky/mmb#getting-started) section to learn how to install this or other services.
 
+## How to migrate from Rocket.Chat 0.70+ to 1.0+
+
+* Stop and remove the current Rocket.Chat and MongoDB containers.
+* Run the up-to-dated containers. Note that the Rocket.Chat container will crash but don't worry, because it will be fixed soon.
+* run `docker run -it --rm --net=container:rocketchat_mongo_1 mongo:3.2-jessie bash` where `rocketchat_mongo_1` is the name of the MongoDB container.
+* execute the following code in the shell
+  ```
+  mongo mongo/rocketchat --eval "rs.initiate({ _id: 'rs0', members: [ { _id: 0, host: 'localhost:27017' } ]})"
+  ```
+
+  You should get the following message (the Rocket.Chat version may be different):
+
+  ```
+  MongoDB shell version: 3.2.21
+  connecting to: mongo/rocketchat
+  { "ok" : 1 }
+  ```
+* Restart the Rocket.Chat and MongoDB containers. Now everything should be fine.
+
 ## Configuration
 
 `docker-compose.yml` supports the following parameters.

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -12,11 +12,11 @@ Rocket.Chat is a self-hosted alternative to Slack.
   </tr>
   <tr>
     <td>Version</td>
-    <td><a href="https://github.com/RocketChat/Rocket.Chat/releases/tag/0.70.0">0.70</a></td>
+    <td><a href="https://github.com/RocketChat/Rocket.Chat/releases/tag/1.1.0">1.1</a></td>
   </tr>
   <tr>
     <td>Release date</td>
-    <td>27 Sep 2018</td>
+    <td>28 May 2019</td>
   </tr>
   <tr>
     <td>Port</td>

--- a/rocketchat/docker-compose.yml
+++ b/rocketchat/docker-compose.yml
@@ -17,8 +17,4 @@ services:
     ports:
     - "27018:27017"
     command: mongod --oplogSize 128 --replSet rs0
-  mongo-init-replica:
-    image: mongo:3.2-jessie
-    command: 'bash -c "for i in `seq 1 30`; do mongo mongo/rocketchat --eval \"rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})\" && s=$$? && break || s=$$?; echo \"Tried $$i times. Waiting 5 secs...\"; sleep 5; done; (exit $$s)"'
-    depends_on:
-      - mongo
+

--- a/rocketchat/docker-compose.yml
+++ b/rocketchat/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rocketchat:
-    image: cusdeb/rocketchat:1.1.3-amd64
+    image: cusdeb/rocketchat:1.1-amd64
     network_mode: "host"
     environment:
     - PORT=8006

--- a/rocketchat/docker-compose.yml
+++ b/rocketchat/docker-compose.yml
@@ -1,17 +1,24 @@
 version: "2"
 services:
   rocketchat:
-    image: cusdeb/rocketchat:0.70-amd64
+    image: cusdeb/rocketchat:1.1.3-amd64
     network_mode: "host"
     environment:
     - PORT=8006
     - MONGO_DATABASE=rocketchat
     - MONGO_HOST=127.0.0.1:27018
+    - MONGO_OPLOG_HOST=127.0.0.1:27018
     - ROOT_URL=http://127.0.0.1:8006
   mongo:
     image: mongo:3.2-jessie
+    restart: unless-stopped
     volumes:
     - /srv/mongo:/data/db
     ports:
     - "27018:27017"
-
+    command: mongod --oplogSize 128 --replSet rs0
+  mongo-init-replica:
+    image: mongo:3.2-jessie
+    command: 'bash -c "for i in `seq 1 30`; do mongo mongo/rocketchat --eval \"rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})\" && s=$$? && break || s=$$?; echo \"Tried $$i times. Waiting 5 secs...\"; sleep 5; done; (exit $$s)"'
+    depends_on:
+      - mongo

--- a/rocketchat/docker-compose.yml
+++ b/rocketchat/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     - ROOT_URL=http://127.0.0.1:8006
   mongo:
     image: mongo:3.2-jessie
-    restart: unless-stopped
     volumes:
     - /srv/mongo:/data/db
     ports:

--- a/rocketchat/docker-entrypoint.sh
+++ b/rocketchat/docker-entrypoint.sh
@@ -5,6 +5,7 @@ host="$(echo ${MONGO_HOST} | cut -d':' -f1)"
 port="$(echo ${MONGO_HOST} | cut -d':' -f2)"
 
 export MONGO_URL="mongodb://${MONGO_HOST}/${MONGO_DATABASE}"
+export MONGO_OPLOG_URL="mongodb://${MONGO_OPLOG_HOST}/local?replSet=rs01"
 
 wait-for-it.sh -h "${host}" -p "${port}" -t 90 -- >&2 echo "MongoDB is ready"
 


### PR DESCRIPTION
We need to check the following Hubot scripts with this version of RC:
* https://github.com/tolstoyevsky/hubot-huntflow-reloaded
* https://github.com/tolstoyevsky/hubot-viva-las-vegas
* https://github.com/tolstoyevsky/hubot-happy-birthder
* https://github.com/tolstoyevsky/hubot-help
* https://github.com/tolstoyevsky/hubot-vote-or-die

Checklist:
**hubot-huntflow-reloaded**:
- [x] receive webhook from hf and send notification in `hr` channel
- [x] get first working day list
- [x] remove interview

**hubot-viva-las-vegas**:
- [x] invoking `работаю из дома`
- [x] invoking `не работаю из дома`
- [x] invoking `хочу в отпуск`
- [x] approving, cancelling and rejecting leave requests
- [x] checking notification in the `leave-coordination` channel

**hubot-happy-birthder**:
- [x] asking new employees to specify their date birth and reminding them about it if they ignore this request for some reason
- [x] writing birthday messages to `#general`
- [x] creating birthday channels automatically
- [x] removing birthday channels automatically
- [x] memorizing the date when a new employee logs in to Rocket.Chat for the first time
- [x] congratulating employees on anniversary of working in the company
- [x] fetching a random GIF from Tenor before writing a birthday message to a birthday boy/girl
- [x] reminding users of the upcoming birthdays one day and a few days in advance

**hubot-help**:

- [x] invoking `help`
- [x] expanding/collapsing the blocks of commands

**hubot-vote-or-die**:

- [x] creating polls (up to 12 possible options)
- [x] making sure it's not possible to create polls with more than 12 options


