### PR TITLE
hubot-rocketchat: do not use host network

### DIFF
--- a/hubot-rocketchat/README.md
+++ b/hubot-rocketchat/README.md
@@ -27,6 +27,7 @@ Rocket.Chat Hubot adapter is the way to integrate [Hubot](https://hubot.github.c
 
 * [Features](#features)
 * [Installation](#installation)
+* [Note to macOS users](#note-to-macos-users)
 * [Configuration](#configuration)
 * [Installing external scripts](#installing-external-scripts)
 * [Debugging](#debugging)
@@ -49,6 +50,10 @@ The following set of scripts makes the bot capable of doing all sort of things:
 ## Installation
 
 Read the [Getting Started](https://github.com/tolstoyevsky/mmb#getting-started) section to learn how to install this or other services.
+
+## Note to macOS users
+
+macOS doesn't have the `/srv` directory which the Redis service relies on. Moreover, it's not possible to create that directory because of [System Integrity Protection](https://arstechnica.com/gadgets/2015/09/os-x-10-11-el-capitan-the-ars-technica-review/8/#h1) (or simply SIP), so edit `docker-compose.yml` to replace `/srv/redis-dump:/dump` to `./redis-dump:/dump`.
 
 ## Configuration
 
@@ -141,7 +146,7 @@ By default, the packages from the list <a href="#features">above</a> will be ins
   <tr>
     <td>REDIS_URL</td>
     <td>Domain or IP of the Redis host.</td>
-    <td>redis://127.0.0.1:16379</td>
+    <td>redis://redis:6379</td>
   </tr>
   <tr>
     <td align="center" colspan="3"><b>hubot-viva-las-vegas</b></td>

--- a/hubot-rocketchat/docker-compose-armhf.yml
+++ b/hubot-rocketchat/docker-compose-armhf.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   hubot-rocketchat:
     image: cusdeb/hubot-rocketchat:2.0-armhf
-    network_mode: "host"
+    network_mode: "container:rocketchat_rocketchat_1"
     environment:
     - AUTH_ATTEMPTS=${AUTH_ATTEMPTS}
     - DEBUG=${DEBUG}
@@ -57,11 +57,8 @@ services:
     - ./packages:/home/hubot/packages
     - ./scripts:/home/hubot/scripts
   redis:
-    image: cusdeb/redis:5.0-armhf
-    network_mode: "host"
+    image: cusdeb/redis:5.0-amd64
     environment:
-    - REDIS_CONF_bind=127.0.0.1
-    - REDIS_CONF_port=16379
     # Enable AOF
     - REDIS_CONF_appendonly=yes
     # Disable RDB

--- a/hubot-rocketchat/docker-compose.yml
+++ b/hubot-rocketchat/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   hubot-rocketchat:
     image: cusdeb/hubot-rocketchat:2.0-amd64
-    network_mode: "host"
+    network_mode: "container:rocketchat_rocketchat_1"
     environment:
     - AUTH_ATTEMPTS=${AUTH_ATTEMPTS}
     - DEBUG=${DEBUG}
@@ -58,10 +58,7 @@ services:
     - ./scripts:/home/hubot/scripts
   redis:
     image: cusdeb/redis:5.0-amd64
-    network_mode: "host"
     environment:
-    - REDIS_CONF_bind=127.0.0.1
-    - REDIS_CONF_port=16379
     # Enable AOF
     - REDIS_CONF_appendonly=yes
     # Disable RDB

--- a/hubot-rocketchat/docker-entrypoint.sh
+++ b/hubot-rocketchat/docker-entrypoint.sh
@@ -27,7 +27,7 @@ RESPOND_TO_DM=${RESPOND_TO_DM:=true}
 TZ=${TZ:="Europe/Moscow"}
 
 # hubot-redis-brain script
-REDIS_URL=${REDIS_URL:="redis://127.0.0.1:16379"}
+REDIS_URL=${REDIS_URL:="redis://redis:6379"}
 
 set +x
 


### PR DESCRIPTION
The main purpose of the PR is to allow macOS users to work on the bot.