### PR TITLE
hubot-rocketchat: update default EXTERNAL_SCRIPTS

### DIFF
--- a/hubot-rocketchat/docker-entrypoint.sh
+++ b/hubot-rocketchat/docker-entrypoint.sh
@@ -16,7 +16,7 @@ ROCKETCHAT_USER=${ROCKETCHAT_USER:="meeseeks"}
 
 ROCKETCHAT_PASSWORD=${ROCKETCHAT_PASSWORD:="pass"}
 
-EXTERNAL_SCRIPTS=${EXTERNAL_SCRIPTS:="git:tolstoyevsky/hubot-happy-birthder,git:tolstoyevsky/hubot-help,git:tolstoyevsky/hubot-pugme,hubot-reaction,git:hubotio/hubot-redis-brain,hubot-thesimpsons,git:tolstoyevsky/hubot-vote-or-die"}
+EXTERNAL_SCRIPTS=${EXTERNAL_SCRIPTS:="git:tolstoyevsky/hubot-happy-birthder,git:tolstoyevsky/hubot-help,git:tolstoyevsky/hubot-huntflow-reloaded,git:tolstoyevsky/hubot-pugme,hubot-reaction,git:hubotio/hubot-redis-brain,hubot-thesimpsons,git:tolstoyevsky/hubot-viva-las-vegas,git:tolstoyevsky/hubot-vote-or-die"}
 
 HUBOT_NAME=${HUBOT_NAME:="bot"}
 


### PR DESCRIPTION
Add `hubot-huntflow-reloaded` and `hubot-viva-las-vegas` extensions to default value

close #150 