### PR TITLE
hubot-rocketchat: fix bug with broken debug mode

### DIFF
--- a/hubot-rocketchat/docker-compose.yml
+++ b/hubot-rocketchat/docker-compose.yml
@@ -64,6 +64,8 @@ services:
     - ./scripts:/root/hubot/scripts
     volumes_from:
       - socket
+    ports:
+    - "9229:9229"
   redis:
     image: cusdeb/redis:5.0-amd64
     environment:

--- a/hubot-rocketchat/docker-entrypoint.sh
+++ b/hubot-rocketchat/docker-entrypoint.sh
@@ -143,7 +143,7 @@ npm install
 export PATH="/usr/lib/node_modules/hubot/bin:/usr/local/share/npm/bin:/root/hubot/node_modules/hubot/bin:$PATH"
 
 if ${DEBUG}; then
-    coffee --nodejs --inspect hubot -n "${BOT_NAME}" -a rocketchat "$@"
+    coffee --nodejs --inspect=0.0.0.0:9229 node_modules/.bin/hubot -n "${BOT_NAME}" -a rocketchat "$@"
 else
     exec hubot -n "${BOT_NAME}" -a rocketchat "$@"
 fi


### PR DESCRIPTION
- [x] Tested on Linux
- [ ] Tested on Mac OS

**Testing checklist:**
- Set up remote debugging in your text editor or IDE;
- Add `debugger` keywork anywhere in code;
- Run `hubot-rocketchat` with environment variable `DEBUG=true`;
- Connect to remote debug server with your debugger software;
- Make the debugger stop at a breakpoint;
- Make sure the debugger is working.