### PR TITLE
hubot-rocketchat: use host network (again)

### DIFF
--- a/hubot-rocketchat/docker-compose.yml
+++ b/hubot-rocketchat/docker-compose.yml
@@ -1,14 +1,8 @@
 version: "2"
 services:
-  socket:
-    image: busybox
-    command: chmod -R 777 /var/run
-    volumes:
-      - /var/run
   hubot-rocketchat:
     image: cusdeb/hubot-rocketchat:2.0-amd64
-    networks:
-    - rocketchat_rocketchat-network
+    network_mode: host
     environment:
     - AUTH_ATTEMPTS=${AUTH_ATTEMPTS}
     - DEBUG=${DEBUG}
@@ -62,10 +56,9 @@ services:
     volumes:
     - ./packages:/root/hubot/packages
     - ./scripts:/root/hubot/scripts
-    volumes_from:
-      - socket
   redis:
     image: cusdeb/redis:5.0-amd64
+    network_mode: host
     environment:
     # Enable AOF
     - REDIS_CONF_appendonly=yes
@@ -76,8 +69,4 @@ services:
     - REDIS_CONF_unixsocketperm=777
     volumes:
     - /srv/redis-dump:/dump
-    volumes_from:
-      - socket
-networks:
-  rocketchat_rocketchat-network:
-    external: true
+

--- a/hubot-rocketchat/docker-entrypoint.sh
+++ b/hubot-rocketchat/docker-entrypoint.sh
@@ -27,7 +27,7 @@ RESPOND_TO_DM=${RESPOND_TO_DM:=true}
 TZ=${TZ:="Europe/Moscow"}
 
 # hubot-redis-brain script
-REDIS_URL=${REDIS_URL:="redis:///var/run/hubot-redis.sock"}
+REDIS_URL=${REDIS_URL:="redis://127.0.0.1:6379"}
 
 set +x
 


### PR DESCRIPTION
Previously, there was an attempt to avoid using the host networking stack to let macOS user develop the bot, but the solution turned out buggy.