### PR TITLE
mwlib: rename PORT into RENDER_SERVER_PORT

### DIFF
--- a/mediawiki/docker-compose.yml
+++ b/mediawiki/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     image: cusdeb/mwlib:0.16.2
     network_mode: "host"
     environment:
-    - PORT=${PORT}
+    - RENDER_SERVER_PORT=${RENDER_SERVER_PORT}
     - TYPE=nserve
   nslave:
     image: cusdeb/mwlib:0.16.2

--- a/mwlib/docker-compose.yml
+++ b/mwlib/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: cusdeb/mwlib:0.16.2
     network_mode: "host"
     environment:
-    - PORT=${PORT}
+    - RENDER_SERVER_PORT=${RENDER_SERVER_PORT}
     - TYPE=nserve
   nslave:
     image: cusdeb/mwlib:0.16.2

--- a/mwlib/docker-entrypoint.sh
+++ b/mwlib/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PORT=${PORT:=8007}
+export RENDER_SERVER_PORT=${RENDER_SERVER_PORT:=8007}
 
 export MW_QSERVE_PORT=${MW_QSERVE_PORT:=14311}
 
@@ -20,7 +20,7 @@ postman)
 nserve)
     wait-for-it.sh -h 127.0.0.1 -p "${MW_QSERVE_PORT}" -t 90 -- >&2 echo "mw-qserve is ready"
 
-    nserve --port="${PORT}"
+    nserve --port="${RENDER_SERVER_PORT}"
 
     ;;
 nslave)


### PR DESCRIPTION
Otherwise, it conflicts with the PORT variable from `mediawiki/docker-entrypoint.sh`